### PR TITLE
Update harbour-wordle-sv.ts

### DIFF
--- a/translations/harbour-wordle-sv.ts
+++ b/translations/harbour-wordle-sv.ts
@@ -26,7 +26,7 @@
     <message id="wordle-settings-show_play_time">
         <source>Show timer</source>
         <extracomment>Text switch label</extracomment>
-        <translation type="unfinished">Visa timer</translation>
+        <translation>Visa tidur</translation>
     </message>
     <message id="wordle-settings-version">
         <source>Version %1</source>


### PR DESCRIPTION
Timer is actually an English word which is totally unnecessary in the Swedish language, as we already have an all-Swedish word for the same thing.  ;)