### PR TITLE
Tweak Polish keyboard layout

### DIFF
--- a/data/pl/language.json
+++ b/data/pl/language.json
@@ -1,5 +1,5 @@
 {
     "name": "Polski",
     "enconding": "windows-1250",
-    "keypad": [ "qwertzuiopżó", "asdfghjklłęą", "\nyxcvbnmśńć\b" ]
+    "keypad": [ "ąęóśćńżź\r", "qwertyuiop", "asdfghjklł", "zxcvbnm\b" ]
 }


### PR DESCRIPTION
QWERTZ => QWERTY and add missing  Ź

![image](https://github.com/user-attachments/assets/a9e7813b-1179-4ef2-93dc-466ea713dd47)